### PR TITLE
Fix yarn mapping conflict

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@ org.gradle.daemon=false
 
 # Forge Properties
 minecraft_version=1.20.1
-loader_version=47.0.19
-forge_version=1.20.1-47.0.19
+loader_version=47.1.0
+forge_version=1.20.1-47.1.0
 
 # Mod Properties
-mod_version=0.0.16-1.20.1-forge
+mod_version=0.0.18-1.20.1-forge
 maven_group=net.veroxuniverse.epicsamurai
 archives_base_name=epicsamurai
 

--- a/src/main/java/net/veroxuniverse/epicsamurai/entity/custom/JorogumoEntity.java
+++ b/src/main/java/net/veroxuniverse/epicsamurai/entity/custom/JorogumoEntity.java
@@ -150,7 +150,7 @@ public class JorogumoEntity extends Monster implements GeoEntity {
     }
 
     public boolean onClimbable() {
-        return this.isClimbing();
+        return this.isCurrentlyClimbing();
     }
 
     public void makeStuckInBlock(BlockState state, Vec3 vec3) {
@@ -173,7 +173,7 @@ public class JorogumoEntity extends Monster implements GeoEntity {
         return super.canBeAffected(effectInstance);
     }
 
-    public boolean isClimbing() {
+    public boolean isCurrentlyClimbing() {
         return (this.entityData.get(DATA_FLAGS_ID) & 1) != 0;
     }
 


### PR DESCRIPTION
JorogumoEntity has a method name that exists in yarn-mapped `LivingEntity` which it extends causing a mapping conflict.

Change:
```patch
-- JorogumoEntity#imClimbing
++ JorogumoEntity#isCurrentlyClimbing
```

To Fix:
```gradle
:remapping 1 mods from modImplementation (java-api)
  METHODs net/veroxuniverse/epicsamurai/entity/custom/JorogumoEntity/[net/minecraft/world/entity/LivingEntity/m_6147_, isClimbing]()Z -> isClimbing
Mapping target name conflicts detected:
There were unfixable conflicts.
```