### PR TITLE
Kitsune mask epic fight compatibility fix

### DIFF
--- a/src/main/java/net/veroxuniverse/samurai_dynasty/curios/layers/KitsuneMaskRenderer.java
+++ b/src/main/java/net/veroxuniverse/samurai_dynasty/curios/layers/KitsuneMaskRenderer.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.ItemRenderer;
@@ -15,8 +16,9 @@ import net.minecraft.world.item.ItemStack;
 import net.veroxuniverse.samurai_dynasty.curios.model.KitsuneMaskModel;
 import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.client.ICurioRenderer;
+import top.theillusivec4.curios.api.client.ICurioRenderer.HumanoidRender;
 
-public class KitsuneMaskRenderer implements ICurioRenderer {
+public class KitsuneMaskRenderer implements HumanoidRender {
     private static final ResourceLocation KITSUNE_MASK_LOCATION = new ResourceLocation("samurai_dynasty:textures/armor/kitsune_mask.png");
     private final KitsuneMaskModel kitsuneMaskModel;
 
@@ -37,4 +39,14 @@ public class KitsuneMaskRenderer implements ICurioRenderer {
         VertexConsumer vertexconsumer = ItemRenderer.getArmorFoilBuffer(renderTypeBuffer, RenderType.armorCutoutNoCull(KITSUNE_MASK_LOCATION), false, stack.hasFoil());
         this.kitsuneMaskModel.renderToBuffer(matrixStack, vertexconsumer, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F, 1.0F);
     }
+
+    @Override
+	public HumanoidModel<LivingEntity> getModel(ItemStack arg0, SlotContext arg1) {
+		return this.kitsuneMaskModel;
+	}
+	
+	@Override
+	public ResourceLocation getModelTexture(ItemStack arg0, SlotContext arg1) {
+		return KITSUNE_MASK_LOCATION;
+	}
 }


### PR DESCRIPTION
In the latest curios api, they have an extended interface that allows you to return the model and the texture will be rendered through `ICuriosRenderer`. Epic Fight uses the interface to transform the model from vanilla to epic fight formatted. This fix will allow Kitsune Mask in mask slot to be rendered in the proper location.